### PR TITLE
chore: upgrade electron to v37

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "chai": "^4.3.8",
         "chai-as-promised": "^7.1.1",
         "conventional-changelog-conventionalcommits": "^8.0.0",
-        "electron": "^35.1.2",
+        "electron": "^37.0.0",
         "electron-mocks": "file:./",
         "eslint": "^9.16.0",
         "eslint-config-prettier": "^9.1.0",
@@ -3444,11 +3444,12 @@
       "dev": true
     },
     "node_modules/electron": {
-      "version": "35.1.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-35.1.2.tgz",
-      "integrity": "sha512-ipYSDZEV3+PpHfJ8/oWlpMCvxwutX6xLvBz2HRPgEzSFzgLmGO7YXTjEow4DhDtCpGE+b95NTGoJaRAVQi5n7A==",
+      "version": "37.2.6",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-37.2.6.tgz",
+      "integrity": "sha512-Ns6xyxE+hIK5UlujtRlw7w4e2Ju/ImCWXf1Q/PoOhc0N3/6SN6YW7+ujCarsHbxWnolbW+1RlkHtdklUJpjbPA==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@electron/get": "^2.0.0",
         "@types/node": "^22.7.7",
@@ -13804,9 +13805,9 @@
       "dev": true
     },
     "electron": {
-      "version": "35.1.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-35.1.2.tgz",
-      "integrity": "sha512-ipYSDZEV3+PpHfJ8/oWlpMCvxwutX6xLvBz2HRPgEzSFzgLmGO7YXTjEow4DhDtCpGE+b95NTGoJaRAVQi5n7A==",
+      "version": "37.2.6",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-37.2.6.tgz",
+      "integrity": "sha512-Ns6xyxE+hIK5UlujtRlw7w4e2Ju/ImCWXf1Q/PoOhc0N3/6SN6YW7+ujCarsHbxWnolbW+1RlkHtdklUJpjbPA==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",
@@ -13835,7 +13836,7 @@
         "chai": "^4.3.8",
         "chai-as-promised": "^7.1.1",
         "conventional-changelog-conventionalcommits": "^8.0.0",
-        "electron": "^35.1.2",
+        "electron": "^37.0.0",
         "electron-mocks": "file:",
         "eslint": "^9.16.0",
         "eslint-config-prettier": "^9.1.0",
@@ -16347,9 +16348,9 @@
           "dev": true
         },
         "electron": {
-          "version": "35.1.2",
-          "resolved": "https://registry.npmjs.org/electron/-/electron-35.1.2.tgz",
-          "integrity": "sha512-ipYSDZEV3+PpHfJ8/oWlpMCvxwutX6xLvBz2HRPgEzSFzgLmGO7YXTjEow4DhDtCpGE+b95NTGoJaRAVQi5n7A==",
+          "version": "37.2.6",
+          "resolved": "https://registry.npmjs.org/electron/-/electron-37.2.6.tgz",
+          "integrity": "sha512-Ns6xyxE+hIK5UlujtRlw7w4e2Ju/ImCWXf1Q/PoOhc0N3/6SN6YW7+ujCarsHbxWnolbW+1RlkHtdklUJpjbPA==",
           "dev": true,
           "requires": {
             "@electron/get": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "chai": "^4.3.8",
     "chai-as-promised": "^7.1.1",
     "conventional-changelog-conventionalcommits": "^8.0.0",
-    "electron": "^35.1.2",
+    "electron": "^37.0.0",
     "electron-mocks": "file:./",
     "eslint": "^9.16.0",
     "eslint-config-prettier": "^9.1.0",

--- a/src/MockBrowserWindow.ts
+++ b/src/MockBrowserWindow.ts
@@ -73,6 +73,8 @@ export class MockBrowserWindow extends EventEmitter implements BrowserWindow {
   private _title = ''
   private _modal = false
   private _skipTaskbar = false
+  private _contentProtected = false
+  private _snapped = false
 
   // methods
   destroy = sinon.spy(() => {
@@ -353,7 +355,14 @@ export class MockBrowserWindow extends EventEmitter implements BrowserWindow {
   })
   isVisibleOnAllWorkspaces = sinon.spy(() => this._visibleOnAllWorkspaces)
   setIgnoreMouseEvents = sinon.spy()
-  setContentProtection = sinon.spy()
+  setContentProtection = sinon.spy((enable: boolean) => {
+    this._contentProtected = enable
+  })
+  isContentProtected = sinon.spy(() => this._contentProtected)
+  get snapped(): boolean {
+    return this._snapped
+  }
+  isSnapped = sinon.spy(() => this._snapped)
   setFocusable = sinon.spy((focusable: boolean) => {
     this.focusable = focusable
   })


### PR DESCRIPTION
## Summary
- upgrade dev electron to v37
- mock new BrowserWindow APIs for snapping and content protection

## Testing
- `npm run type-check`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68994b4952388328bc95ae3940596a13