### PR TITLE
docs: remove duplicate MockView entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ Currently implemented:
 - [MockDisplay](src/MockDisplay.ts)
 - [MockAutoUpdater](src/MockAutoUpdater.ts)
 - [MockDownloadItem](src/MockDownloadItem.ts)
-- [MockView](src/MockView.ts)
 
 All methods are implemented and should return logical values. Additionally, methods are wrapped in [sinon.spy()]([url](https://sinonjs.org/releases/latest/spies/)) so calls can be queried. All logical events should be emitted.
 


### PR DESCRIPTION
## Summary
- remove duplicate MockView entry from documentation

## Testing
- `npm test` *(fails: Cannot find module 'electron-mocks/dist/cjs/index.js')*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68996274631c832895aa23d8bc0b3647