### PR TITLE
fix: newer e37 compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "chai": "^4.3.8",
         "chai-as-promised": "^7.1.1",
         "conventional-changelog-conventionalcommits": "^8.0.0",
-        "electron": "^37.0.0",
+        "electron": "^37.3.1",
         "electron-mocks": "file:./",
         "eslint": "^9.16.0",
         "eslint-config-prettier": "^9.1.0",
@@ -3444,9 +3444,9 @@
       "dev": true
     },
     "node_modules/electron": {
-      "version": "37.2.6",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-37.2.6.tgz",
-      "integrity": "sha512-Ns6xyxE+hIK5UlujtRlw7w4e2Ju/ImCWXf1Q/PoOhc0N3/6SN6YW7+ujCarsHbxWnolbW+1RlkHtdklUJpjbPA==",
+      "version": "37.3.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-37.3.1.tgz",
+      "integrity": "sha512-7DhktRLqhe6OJh/Bo75bTI0puUYEmIwSzMinocgO63mx3MVjtIn2tYMzLmAleNIlud2htkjpsMG2zT4PiTCloA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -13805,9 +13805,9 @@
       "dev": true
     },
     "electron": {
-      "version": "37.2.6",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-37.2.6.tgz",
-      "integrity": "sha512-Ns6xyxE+hIK5UlujtRlw7w4e2Ju/ImCWXf1Q/PoOhc0N3/6SN6YW7+ujCarsHbxWnolbW+1RlkHtdklUJpjbPA==",
+      "version": "37.3.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-37.3.1.tgz",
+      "integrity": "sha512-7DhktRLqhe6OJh/Bo75bTI0puUYEmIwSzMinocgO63mx3MVjtIn2tYMzLmAleNIlud2htkjpsMG2zT4PiTCloA==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",
@@ -13836,7 +13836,7 @@
         "chai": "^4.3.8",
         "chai-as-promised": "^7.1.1",
         "conventional-changelog-conventionalcommits": "^8.0.0",
-        "electron": "^37.0.0",
+        "electron": "^37.3.1",
         "electron-mocks": "file:",
         "eslint": "^9.16.0",
         "eslint-config-prettier": "^9.1.0",
@@ -16348,9 +16348,9 @@
           "dev": true
         },
         "electron": {
-          "version": "37.2.6",
-          "resolved": "https://registry.npmjs.org/electron/-/electron-37.2.6.tgz",
-          "integrity": "sha512-Ns6xyxE+hIK5UlujtRlw7w4e2Ju/ImCWXf1Q/PoOhc0N3/6SN6YW7+ujCarsHbxWnolbW+1RlkHtdklUJpjbPA==",
+          "version": "37.3.1",
+          "resolved": "https://registry.npmjs.org/electron/-/electron-37.3.1.tgz",
+          "integrity": "sha512-7DhktRLqhe6OJh/Bo75bTI0puUYEmIwSzMinocgO63mx3MVjtIn2tYMzLmAleNIlud2htkjpsMG2zT4PiTCloA==",
           "dev": true,
           "requires": {
             "@electron/get": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "chai": "^4.3.8",
     "chai-as-promised": "^7.1.1",
     "conventional-changelog-conventionalcommits": "^8.0.0",
-    "electron": "^37.0.0",
+    "electron": "^37.3.1",
     "electron-mocks": "file:./",
     "eslint": "^9.16.0",
     "eslint-config-prettier": "^9.1.0",

--- a/src/MockApp.ts
+++ b/src/MockApp.ts
@@ -138,4 +138,8 @@ export class MockApp extends EventEmitter implements Electron.App {
   constructor() {
     super()
   }
+
+  getRecentDocuments(): string[] {
+    return []
+  }
 }

--- a/src/MockBrowserWindow.ts
+++ b/src/MockBrowserWindow.ts
@@ -75,6 +75,7 @@ export class MockBrowserWindow extends EventEmitter implements BrowserWindow {
   private _skipTaskbar = false
   private _contentProtected = false
   private _snapped = false
+  private _accentColor: string | boolean = false
 
   // methods
   destroy = sinon.spy(() => {
@@ -470,4 +471,13 @@ export class MockBrowserWindow extends EventEmitter implements BrowserWindow {
       if (this._visible) this.emit('show')
     })
   }
+  getAccentColor(): string | boolean {
+    return this._accentColor
+  }
+
+  setAccentColor(accentColor: boolean | string): void {
+    this._accentColor = accentColor
+  }
+
+  tabbingIdentifier?: string
 }


### PR DESCRIPTION
This pull request introduces minor updates to dependencies and adds support for new Electron APIs in the mock classes used for testing. The primary changes are the upgrade of the Electron dependency and the addition of `getAccentColor`/`setAccentColor` methods to `MockBrowserWindow`, along with `getRecentDocuments` to `MockApp`.

**Dependency Update:**
* Upgraded the `electron` dependency in `package.json` from version `^37.0.0` to `^37.3.1` to ensure compatibility with the latest Electron features and bug fixes.

**Mock Class Enhancements:**
* Added the `getAccentColor` and `setAccentColor` methods, as well as the `_accentColor` property, to the `MockBrowserWindow` class to support testing of accent color features. [[1]](diffhunk://#diff-3edad9f15aed7d91c1fa53d2018cc377154ea688b60614e88ef82219acaa07e9R78) [[2]](diffhunk://#diff-3edad9f15aed7d91c1fa53d2018cc377154ea688b60614e88ef82219acaa07e9R474-R482)
* Added the `getRecentDocuments` method to the `MockApp` class to mock the corresponding Electron API, returning an empty array.